### PR TITLE
Add mutation observer

### DIFF
--- a/lib/next-tick.js
+++ b/lib/next-tick.js
@@ -1,10 +1,23 @@
 'use strict';
 
+var root = typeof window !== 'undefined' ? window :
+		typeof global !== 'undefined' ? global : {};
+
 if ((typeof process !== 'undefined') && process &&
 		(typeof process.nextTick === 'function')) {
 
 	// Node.js
 	module.exports = process.nextTick;
+
+} else if (typeof MutationObserver !== 'undefined' ||
+		typeof WebkitMutationObserver !== 'undefined') {
+
+	var Observer = root.MutationObserver || root.WebkitMutationObserver;
+	module.exports = function (cb) {
+		var elem = document.createElement('div')
+		new Observer(cb).observe(elem, { attributes: true })
+		elem.setAttribute('x', 'y')
+	};
 
 } else if (typeof setImmediate === 'function') {
 


### PR DESCRIPTION
`setImmediate` does not have the recursive blocking loop semantic of node 0.10 [process.nextTick](http://nodejs.org/api/process.html#process_process_nexttick_callback)

Whether or not this event loop starving functionality is good or bad is besides the point. If you want starving use `require('next-tick')`. If you don't want starving use `require('setimmediate')`

With this addition `next-tick` will starve the event loop in node 0.10 and any browsers that support [MutationObserver](http://caniuse.com/mutationobserver)
