### PR TITLE
Simplify selection conditions

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,12 +44,12 @@ var byObserver = function (Observer) {
 
 module.exports = (function () {
 	// Node.js
-	if ((typeof process === 'object') && process && (typeof process.nextTick === 'function')) {
+	if (typeof process === 'object' && typeof process.nextTick === 'function') {
 		return process.nextTick;
 	}
 
 	// MutationObserver
-	if ((typeof document === 'object') && document) {
+	if (typeof document === 'object' && document.createTextNode) {
 		if (typeof MutationObserver === 'function') return byObserver(MutationObserver);
 		if (typeof WebKitMutationObserver === 'function') return byObserver(WebKitMutationObserver);
 	}


### PR DESCRIPTION
If `document`/`process` is an `object`, it doesn't need to be checked again (`&& process`)

If we're checking for `document` instead of just `MutationObserver`, we might as well also make sure that `document.createTextNode` is available.