### PR TITLE
provide browser specific entry point to reduce browserify bundle bloat

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var ensureCallable = function (fn) {
+  if (typeof fn !== 'function') throw new TypeError(fn + " is not a function");
+  return fn;
+};
+
+var byObserver = function (Observer) {
+  var node = document.createTextNode(''), queue, currentQueue, i = 0;
+  new Observer(function () {
+    var callback;
+    if (!queue) {
+      if (!currentQueue) return;
+      queue = currentQueue;
+    } else if (currentQueue) {
+      queue = currentQueue.concat(queue);
+    }
+    currentQueue = queue;
+    queue = null;
+    if (typeof currentQueue === 'function') {
+      callback = currentQueue;
+      currentQueue = null;
+      callback();
+      return;
+    }
+    node.data = (i = ++i % 2); // Invoke other batch, to handle leftover callbacks in case of crash
+    while (currentQueue) {
+      callback = currentQueue.shift();
+      if (!currentQueue.length) currentQueue = null;
+      callback();
+    }
+  }).observe(node, { characterData: true });
+  return function (fn) {
+    ensureCallable(fn);
+    if (queue) {
+      if (typeof queue === 'function') queue = [queue, fn];
+      else queue.push(fn);
+      return;
+    }
+    queue = fn;
+    node.data = (i = ++i % 2);
+  };
+};
+
+module.exports = (function () {
+  // MutationObserver
+  if ((typeof document === 'object') && document) {
+    if (typeof MutationObserver === 'function') return byObserver(MutationObserver);
+    if (typeof WebKitMutationObserver === 'function') return byObserver(WebKitMutationObserver);
+  }
+
+  // W3C Draft
+  // http://dvcs.w3.org/hg/webperf/raw-file/tip/specs/setImmediate/Overview.html
+  if (typeof setImmediate === 'function') {
+    return function (cb) { setImmediate(ensureCallable(cb)); };
+  }
+
+  // Wide available standard
+  if ((typeof setTimeout === 'function') || (typeof setTimeout === 'object')) {
+    return function (cb) { setTimeout(ensureCallable(cb), 0); };
+  }
+
+  return null;
+}());

--- a/browser.js
+++ b/browser.js
@@ -1,64 +1,64 @@
 'use strict';
 
 var ensureCallable = function (fn) {
-  if (typeof fn !== 'function') throw new TypeError(fn + " is not a function");
-  return fn;
+	if (typeof fn !== 'function') throw new TypeError(fn + " is not a function");
+	return fn;
 };
 
 var byObserver = function (Observer) {
-  var node = document.createTextNode(''), queue, currentQueue, i = 0;
-  new Observer(function () {
-    var callback;
-    if (!queue) {
-      if (!currentQueue) return;
-      queue = currentQueue;
-    } else if (currentQueue) {
-      queue = currentQueue.concat(queue);
-    }
-    currentQueue = queue;
-    queue = null;
-    if (typeof currentQueue === 'function') {
-      callback = currentQueue;
-      currentQueue = null;
-      callback();
-      return;
-    }
-    node.data = (i = ++i % 2); // Invoke other batch, to handle leftover callbacks in case of crash
-    while (currentQueue) {
-      callback = currentQueue.shift();
-      if (!currentQueue.length) currentQueue = null;
-      callback();
-    }
-  }).observe(node, { characterData: true });
-  return function (fn) {
-    ensureCallable(fn);
-    if (queue) {
-      if (typeof queue === 'function') queue = [queue, fn];
-      else queue.push(fn);
-      return;
-    }
-    queue = fn;
-    node.data = (i = ++i % 2);
-  };
+	var node = document.createTextNode(''), queue, currentQueue, i = 0;
+	new Observer(function () {
+		var callback;
+		if (!queue) {
+			if (!currentQueue) return;
+			queue = currentQueue;
+		} else if (currentQueue) {
+			queue = currentQueue.concat(queue);
+		}
+		currentQueue = queue;
+		queue = null;
+		if (typeof currentQueue === 'function') {
+			callback = currentQueue;
+			currentQueue = null;
+			callback();
+			return;
+		}
+		node.data = (i = ++i % 2); // Invoke other batch, to handle leftover callbacks in case of crash
+		while (currentQueue) {
+			callback = currentQueue.shift();
+			if (!currentQueue.length) currentQueue = null;
+			callback();
+		}
+	}).observe(node, { characterData: true });
+	return function (fn) {
+		ensureCallable(fn);
+		if (queue) {
+			if (typeof queue === 'function') queue = [queue, fn];
+			else queue.push(fn);
+			return;
+		}
+		queue = fn;
+		node.data = (i = ++i % 2);
+	};
 };
 
 module.exports = (function () {
-  // MutationObserver
-  if ((typeof document === 'object') && document) {
-    if (typeof MutationObserver === 'function') return byObserver(MutationObserver);
-    if (typeof WebKitMutationObserver === 'function') return byObserver(WebKitMutationObserver);
-  }
+	// MutationObserver
+	if ((typeof document === 'object') && document) {
+		if (typeof MutationObserver === 'function') return byObserver(MutationObserver);
+		if (typeof WebKitMutationObserver === 'function') return byObserver(WebKitMutationObserver);
+	}
 
-  // W3C Draft
-  // http://dvcs.w3.org/hg/webperf/raw-file/tip/specs/setImmediate/Overview.html
-  if (typeof setImmediate === 'function') {
-    return function (cb) { setImmediate(ensureCallable(cb)); };
-  }
+	// W3C Draft
+	// http://dvcs.w3.org/hg/webperf/raw-file/tip/specs/setImmediate/Overview.html
+	if (typeof setImmediate === 'function') {
+		return function (cb) { setImmediate(ensureCallable(cb)); };
+	}
 
-  // Wide available standard
-  if ((typeof setTimeout === 'function') || (typeof setTimeout === 'object')) {
-    return function (cb) { setTimeout(ensureCallable(cb), 0); };
-  }
+	// Wide available standard
+	if ((typeof setTimeout === 'function') || (typeof setTimeout === 'object')) {
+		return function (cb) { setTimeout(ensureCallable(cb), 0); };
+	}
 
-  return null;
+	return null;
 }());

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "xlint-jslint-medikoo": "^0.1.4"
   },
   "scripts": {
-    "lint": "node node_modules/xlint/bin/xlint --linter=node_modules/xlint-jslint-medikoo/index.js --no-cache --no-stream",
-    "lint-console": "node node_modules/xlint/bin/xlint --linter=node_modules/xlint-jslint-medikoo/index.js --watch",
+    "lint": "xlint --linter=node_modules/xlint-jslint-medikoo/index.js --no-cache --no-stream",
+    "lint-console": "xlint --linter=node_modules/xlint-jslint-medikoo/index.js --watch",
     "test": "tad index.js"
   },
   "browser": "browser.js",

--- a/package.json
+++ b/package.json
@@ -23,5 +23,6 @@
     "lint-console": "node node_modules/xlint/bin/xlint --linter=node_modules/xlint-jslint-medikoo/index.js --watch",
     "test": "node node_modules/tad/bin/tad"
   },
+  "browser": "browser.js",
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "lint": "node node_modules/xlint/bin/xlint --linter=node_modules/xlint-jslint-medikoo/index.js --no-cache --no-stream",
     "lint-console": "node node_modules/xlint/bin/xlint --linter=node_modules/xlint-jslint-medikoo/index.js --watch",
-    "test": "node node_modules/tad/bin/tad"
+    "test": "tad index.js"
   },
   "browser": "browser.js",
   "license": "MIT"


### PR DESCRIPTION
using browserify, the current `next-tick` implementation ends up shimming node's `process.nextTick` function automatically. This PR adds a browser field as described here:

https://github.com/substack/browserify-handbook#browser-field


results in a significantly smaller bundle. Before:

```bash
15256 bytes written to bundle.js
```

after:

```bash
9807 bytes written to bundle.js
```