### PR TITLE
avoid shift

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,27 +6,29 @@ var ensureCallable = function (fn) {
 };
 
 var byObserver = function (Observer) {
-	var node = document.createTextNode(''), queue, currentQueue, i = 0;
+	var node = document.createTextNode(''), queue, currentQueue, bit = 0, i = 0;
 	new Observer(function () {
 		var callback;
 		if (!queue) {
 			if (!currentQueue) return;
 			queue = currentQueue;
 		} else if (currentQueue) {
-			queue = currentQueue.concat(queue);
+			queue = currentQueue.slcie(i).concat(queue);
 		}
 		currentQueue = queue;
 		queue = null;
+		j = i;
 		if (typeof currentQueue === 'function') {
 			callback = currentQueue;
 			currentQueue = null;
 			callback();
 			return;
 		}
-		node.data = (i = ++i % 2); // Invoke other batch, to handle leftover callbacks in case of crash
-		while (currentQueue) {
-			callback = currentQueue.shift();
-			if (!currentQueue.length) currentQueue = null;
+		node.data = (bit = ++bit % 2); // Invoke other batch, to handle leftover callbacks in case of crash
+		while (i < currentQueue.length) {
+			callback = currentQueue[j];
+			i++
+			if (i === currentQueue.length) currentQueue = null;
 			callback();
 		}
 	}).observe(node, { characterData: true });
@@ -38,7 +40,7 @@ var byObserver = function (Observer) {
 			return;
 		}
 		queue = fn;
-		node.data = (i = ++i % 2);
+		node.data = (bit = ++bit % 2);
 	};
 };
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var byObserver = function (Observer) {
 		}
 		currentQueue = queue;
 		queue = null;
-		j = i;
+		i = 0;
 		if (typeof currentQueue === 'function') {
 			callback = currentQueue;
 			currentQueue = null;
@@ -26,8 +26,8 @@ var byObserver = function (Observer) {
 		}
 		node.data = (bit = ++bit % 2); // Invoke other batch, to handle leftover callbacks in case of crash
 		while (i < currentQueue.length) {
-			callback = currentQueue[j];
-			i++
+			callback = currentQueue[i];
+			i++;
 			if (i === currentQueue.length) currentQueue = null;
 			callback();
 		}

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var byObserver = function (Observer) {
 			if (!currentQueue) return;
 			queue = currentQueue;
 		} else if (currentQueue) {
-			queue = currentQueue.slcie(i).concat(queue);
+			queue = currentQueue.slice(i).concat(queue);
 		}
 		currentQueue = queue;
 		queue = null;

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function (t, a, d) {
+exports['basics'] = function (t, a, d) {
 	var invoked;
 
 	a(t(function () {
@@ -20,3 +20,19 @@ module.exports = function (t, a, d) {
 		}, 10);
 	}, 10);
 };
+exports['nested'] = function (t, a, d) {
+	var invoked = [];
+	t(function () {
+		invoked.push(0);
+		t(function () {
+			invoked.push(1);
+			t(function () {
+				invoked.push(2);
+			});
+		});
+	});
+	setTimeout(function () {
+		a.deep(invoked, [0, 1, 2], "nested");
+		d();
+	}, 10);
+}


### PR DESCRIPTION
a small optimization based on my work on [the browserify process module](https://github.com/defunctzombie/node-process/blob/77caa43cdaee4ea710aa14d11cea1705293c0ef3/browser.js) using shift on an array can be very slow if there are a lot of things in the queue since engines will often rewrite the whole array each time it's called.

also added another test